### PR TITLE
chore: bump version to 1.1.1 and refactor changelog implementation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -68,11 +68,7 @@
       "access": "public",
       "distTag": "latest"
     },
-    "versionFiles": [
-      "project.json",
-      "package.json",
-      "version.txt"
-    ],
+    "versionFiles": ["project.json", "package.json", "version.txt"],
     "versionPath": "version",
     "projects": {
       "include": ["libs/*", "apps/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@nx-project-release/source",
+  "name": "project-release",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nx-project-release/source",
+      "name": "project-release",
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -41,6 +41,7 @@
         "semver": "^7.7.2",
         "ts-jest": "^29.4.0",
         "ts-node": "10.9.1",
+        "tsc-esm-fix": "^3.1.2",
         "tslib": "^2.3.0",
         "typescript": "~5.9.2",
         "typescript-eslint": "^8.40.0",
@@ -3612,6 +3613,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@topoconfig/extends": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@topoconfig/extends/-/extends-0.16.2.tgz",
+      "integrity": "sha512-sTF+qpWakr5jf1Hn/kkFSi833xPW15s/loMAiKSYSSVv4vDonxf6hwCGzMXjLq+7HZoaK6BgaV72wXr1eY7FcQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "xtends": "target/esm/cli.mjs"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -6613,6 +6624,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/depseek": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.3.tgz",
+      "integrity": "sha512-0Ex/Uoz9Y9oipbqvgSc7FoV2q4GTDGORkg8TGgM9Pd3RyvRzrDYScKplWiqHU7WqckbKN5kukqD0opEayu2bXg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -7969,6 +7987,21 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -9900,6 +9933,19 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -13018,6 +13064,27 @@
         }
       }
     },
+    "node_modules/tsc-esm-fix": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tsc-esm-fix/-/tsc-esm-fix-3.1.2.tgz",
+      "integrity": "sha512-1/OpZssMcEp2ae6DyZV+yvDviofuCdDf7dEWEaBvm/ac8vtS04lFyl0LVs8LQE56vjKHytgzVjPIL9udM4QuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@topoconfig/extends": "^0.16.2",
+        "depseek": "^0.4.1",
+        "fast-glob": "^3.3.2",
+        "fs-extra": "^11.2.0",
+        "json5": "^2.2.3",
+        "type-flag": "^3.0.0"
+      },
+      "bin": {
+        "tsc-esm-fix": "target/esm/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -13114,6 +13181,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
+      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/type-flag?sponsor=1"
       }
     },
     "node_modules/type-is": {
@@ -13255,6 +13332,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unix-crypt-td-js": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nx-project-release/source",
+  "name": "project-release",
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {},
@@ -37,6 +37,7 @@
     "semver": "^7.7.2",
     "ts-jest": "^29.4.0",
     "ts-node": "10.9.1",
+    "tsc-esm-fix": "^3.1.2",
     "tslib": "^2.3.0",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.40.0",

--- a/packages/project-release/package.json
+++ b/packages/project-release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divagnz/nx-project-release",
-  "version": "1.0.7",
+  "version": "1.1.1",
   "description": "Polyglot Nx plugin for releasing any project type using project.json and conventional commits",
   "keywords": [
     "nx",
@@ -11,7 +11,7 @@
   ],
   "author": "Your Name",
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "executors": "./executors.json",
@@ -30,12 +30,8 @@
     "@nx/devkit": ">=21.0.0"
   },
   "dependencies": {
-    "conventional-changelog": "^7.1.1",
     "rxjs": "^7.8.1",
     "semver": "^7.7.2",
     "tslib": "^2.8.1"
-  },
-  "devDependencies": {
-    "@types/conventional-changelog": "^3.1.5"
   }
 }

--- a/packages/project-release/project.json
+++ b/packages/project-release/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "project-release",
+  "name": "@nx-project-release",
   "$schema": "../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/project-release/src",
   "projectType": "library",
@@ -49,7 +49,7 @@
         ]
       }
     },
-    "nx-release-publish": {
+    "project-release": {
       "options": {
         "packageRoot": "dist/{projectRoot}"
       }

--- a/packages/project-release/src/executors/changelog/commit-parser.ts
+++ b/packages/project-release/src/executors/changelog/commit-parser.ts
@@ -1,0 +1,212 @@
+import { execSync } from 'child_process';
+
+export interface ParsedCommit {
+  hash: string;
+  type: string;
+  scope?: string;
+  subject: string;
+  body?: string;
+  breaking: boolean;
+  breakingMessage?: string;
+  footer?: string;
+}
+
+export interface CommitGroup {
+  title: string;
+  commits: ParsedCommit[];
+}
+
+/**
+ * Parse a conventional commit message
+ * Format: type(scope): subject
+ *         BREAKING CHANGE: description
+ * Or: type(scope)!: subject
+ */
+export function parseConventionalCommit(commitMessage: string, hash: string): ParsedCommit | null {
+  const lines = commitMessage.split('\n');
+  const firstLine = lines[0].trim();
+
+  if (!firstLine) return null;
+
+  // Regex: type(scope)?!?: subject
+  const conventionalPattern = /^(\w+)(?:\(([^)]+)\))?(!)?: (.+)$/;
+  const match = firstLine.match(conventionalPattern);
+
+  if (!match) return null;
+
+  const [, type, scope, bangBreaking, subject] = match;
+
+  // Parse body and check for BREAKING CHANGE
+  const body = lines.slice(1).join('\n').trim();
+  const breakingMatch = body.match(/BREAKING CHANGE:\s*(.+)/);
+  const breaking = !!bangBreaking || !!breakingMatch;
+  const breakingMessage = breakingMatch ? breakingMatch[1].trim() : undefined;
+
+  // Extract footer (everything after last blank line)
+  const footerMatch = body.match(/\n\n([^]+)$/);
+  const footer = footerMatch ? footerMatch[1].trim() : undefined;
+
+  return {
+    hash,
+    type: type.toLowerCase(),
+    scope,
+    subject: subject.trim(),
+    body: body || undefined,
+    breaking,
+    breakingMessage,
+    footer
+  };
+}
+
+/**
+ * Get commits from git log since last tag or all commits
+ */
+export function getCommitsFromGit(
+  cwd: string,
+  from?: string,
+  to?: string,
+  projectName?: string
+): string[] {
+  let gitCommand = 'git log --format="%H|%s%n%b%n===END===" --no-merges';
+
+  if (from && to) {
+    gitCommand += ` ${from}..${to}`;
+  } else if (from) {
+    gitCommand += ` ${from}..HEAD`;
+  } else if (projectName) {
+    // Try to find last tag for this project
+    try {
+      const lastTag = execSync(
+        `git tag --list --sort=-version:refname | grep -E "^${projectName}-v|^v" | head -1`,
+        {
+          cwd,
+          encoding: 'utf8',
+          stdio: 'pipe'
+        }
+      ).trim();
+
+      if (lastTag) {
+        gitCommand += ` ${lastTag}..HEAD`;
+      }
+    } catch {
+      // No previous tags, get all commits
+    }
+  }
+
+  try {
+    const output = execSync(gitCommand, {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+
+    if (!output) return [];
+
+    // Split by ===END=== marker
+    const commitBlocks = output.split('===END===').filter(block => block.trim());
+
+    return commitBlocks.map(block => block.trim()).filter(Boolean);
+  } catch (error) {
+    console.error('Failed to get git commits:', error);
+    return [];
+  }
+}
+
+/**
+ * Parse all commits from git log output
+ */
+export function parseCommits(commitBlocks: string[]): ParsedCommit[] {
+  const parsed: ParsedCommit[] = [];
+
+  for (const block of commitBlocks) {
+    const lines = block.split('\n');
+    if (lines.length === 0) continue;
+
+    // First line: hash|subject
+    const firstLine = lines[0];
+    const pipeIndex = firstLine.indexOf('|');
+    if (pipeIndex === -1) continue;
+
+    const hash = firstLine.substring(0, pipeIndex).trim();
+    const message = firstLine.substring(pipeIndex + 1).trim() + '\n' + lines.slice(1).join('\n');
+
+    const commit = parseConventionalCommit(message, hash);
+    if (commit) {
+      parsed.push(commit);
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Filter commits by project scope
+ * Supports: feat(project-name): ...
+ * Or: feat(project-name,other): ...
+ * Or: feat: ... (if no scope, include in all)
+ */
+export function filterCommitsByScope(commits: ParsedCommit[], projectName?: string): ParsedCommit[] {
+  if (!projectName) return commits;
+
+  return commits.filter(commit => {
+    // No scope = applies to all projects
+    if (!commit.scope) return true;
+
+    // Check if scope includes this project
+    const scopes = commit.scope.split(',').map(s => s.trim());
+    return scopes.includes(projectName) || scopes.includes('*');
+  });
+}
+
+/**
+ * Group commits by type
+ */
+export function groupCommitsByType(commits: ParsedCommit[]): Map<string, ParsedCommit[]> {
+  const groups = new Map<string, ParsedCommit[]>();
+
+  for (const commit of commits) {
+    const existing = groups.get(commit.type) || [];
+    existing.push(commit);
+    groups.set(commit.type, existing);
+  }
+
+  return groups;
+}
+
+/**
+ * Get display title for commit type
+ */
+export function getCommitTypeTitle(type: string): string {
+  const titles: Record<string, string> = {
+    feat: 'Features',
+    fix: 'Bug Fixes',
+    docs: 'Documentation',
+    style: 'Styles',
+    refactor: 'Code Refactoring',
+    perf: 'Performance Improvements',
+    test: 'Tests',
+    build: 'Build System',
+    ci: 'Continuous Integration',
+    chore: 'Chores',
+    revert: 'Reverts'
+  };
+
+  return titles[type] || type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+/**
+ * Order for commit types in changelog
+ */
+export const COMMIT_TYPE_ORDER = [
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'docs',
+  'style',
+  'test',
+  'build',
+  'ci',
+  'chore',
+  'revert'
+];

--- a/packages/project-release/src/executors/changelog/conventional-changelog.d.ts
+++ b/packages/project-release/src/executors/changelog/conventional-changelog.d.ts
@@ -1,9 +1,0 @@
-declare module 'conventional-changelog' {
-  export class ConventionalChangelog {
-    constructor(cwdOrGitClient?: string);
-    loadPreset(preset: string): this;
-    context(context: Record<string, unknown>): this;
-    readPackage(): this;
-    write(): AsyncGenerator<string, void>;
-  }
-}

--- a/packages/project-release/src/executors/changelog/markdown-generator.ts
+++ b/packages/project-release/src/executors/changelog/markdown-generator.ts
@@ -1,0 +1,205 @@
+import { ParsedCommit, getCommitTypeTitle, COMMIT_TYPE_ORDER } from './commit-parser';
+
+export interface ChangelogOptions {
+  version?: string;
+  date?: string;
+  projectName?: string;
+  repositoryUrl?: string;
+  compareUrl?: string;
+}
+
+/**
+ * Generate changelog markdown from parsed commits
+ */
+export function generateChangelogMarkdown(
+  commits: ParsedCommit[],
+  options: ChangelogOptions = {}
+): string {
+  if (commits.length === 0) {
+    return '### No changes\n';
+  }
+
+  let markdown = '';
+
+  // Add version header if provided
+  if (options.version) {
+    const date = options.date || new Date().toISOString().split('T')[0];
+    markdown += `## [${options.version}](${options.compareUrl || options.version}) (${date})\n\n`;
+  }
+
+  // Separate breaking changes
+  const breakingChanges = commits.filter(c => c.breaking);
+  const regularCommits = commits.filter(c => !c.breaking);
+
+  // Add breaking changes section first
+  if (breakingChanges.length > 0) {
+    markdown += '### ⚠ BREAKING CHANGES\n\n';
+    for (const commit of breakingChanges) {
+      const scopeText = commit.scope ? `**${commit.scope}:**` : '';
+      const message = commit.breakingMessage || commit.subject;
+      const commitLink = formatCommitLink(commit.hash, options.repositoryUrl);
+      markdown += `* ${scopeText} ${message} (${commitLink})\n`;
+    }
+    markdown += '\n';
+  }
+
+  // Group regular commits by type
+  const grouped = groupByType(regularCommits);
+
+  // Sort types by predefined order
+  const sortedTypes = COMMIT_TYPE_ORDER.filter(type => grouped.has(type));
+
+  // Add any types not in the predefined order
+  for (const type of grouped.keys()) {
+    if (!COMMIT_TYPE_ORDER.includes(type)) {
+      sortedTypes.push(type);
+    }
+  }
+
+  // Generate sections for each type
+  for (const type of sortedTypes) {
+    const typeCommits = grouped.get(type);
+    if (!typeCommits || typeCommits.length === 0) continue;
+
+    markdown += `### ${getCommitTypeTitle(type)}\n\n`;
+
+    for (const commit of typeCommits) {
+      const scopeText = commit.scope ? `**${commit.scope}:**` : '';
+      const commitLink = formatCommitLink(commit.hash, options.repositoryUrl);
+      markdown += `* ${scopeText} ${commit.subject} (${commitLink})\n`;
+    }
+
+    markdown += '\n';
+  }
+
+  return markdown;
+}
+
+/**
+ * Generate a compact single-line changelog
+ */
+export function generateCompactChangelog(commits: ParsedCommit[]): string {
+  if (commits.length === 0) {
+    return 'No changes';
+  }
+
+  const breaking = commits.filter(c => c.breaking).length;
+  const features = commits.filter(c => c.type === 'feat').length;
+  const fixes = commits.filter(c => c.type === 'fix').length;
+  const other = commits.length - breaking - features - fixes;
+
+  const parts: string[] = [];
+  if (breaking > 0) parts.push(`${breaking} breaking`);
+  if (features > 0) parts.push(`${features} features`);
+  if (fixes > 0) parts.push(`${fixes} fixes`);
+  if (other > 0) parts.push(`${other} other`);
+
+  return parts.join(', ');
+}
+
+/**
+ * Group commits by type
+ */
+function groupByType(commits: ParsedCommit[]): Map<string, ParsedCommit[]> {
+  const grouped = new Map<string, ParsedCommit[]>();
+
+  for (const commit of commits) {
+    const existing = grouped.get(commit.type) || [];
+    existing.push(commit);
+    grouped.set(commit.type, existing);
+  }
+
+  return grouped;
+}
+
+/**
+ * Format commit hash as a link or short hash
+ */
+function formatCommitLink(hash: string, repositoryUrl?: string): string {
+  const shortHash = hash.substring(0, 7);
+
+  if (repositoryUrl) {
+    const cleanUrl = repositoryUrl.replace(/\.git$/, '');
+    return `[${shortHash}](${cleanUrl}/commit/${hash})`;
+  }
+
+  return shortHash;
+}
+
+/**
+ * Generate workspace changelog with project sections
+ */
+export function generateWorkspaceChangelog(
+  commitsByProject: Map<string, ParsedCommit[]>,
+  options: ChangelogOptions = {}
+): string {
+  let markdown = '';
+
+  if (options.version) {
+    const date = options.date || new Date().toISOString().split('T')[0];
+    markdown += `# ${options.version} (${date})\n\n`;
+  }
+
+  if (commitsByProject.size === 0) {
+    return markdown + '### No changes\n';
+  }
+
+  // Sort projects alphabetically
+  const sortedProjects = Array.from(commitsByProject.keys()).sort();
+
+  for (const projectName of sortedProjects) {
+    const commits = commitsByProject.get(projectName);
+    if (!commits || commits.length === 0) continue;
+
+    markdown += `## ${projectName}\n\n`;
+    markdown += generateChangelogMarkdown(commits, { ...options, projectName });
+  }
+
+  // Add commits without specific scope (global changes)
+  const globalCommits = Array.from(commitsByProject.values())
+    .flat()
+    .filter(c => !c.scope || c.scope === '*');
+
+  if (globalCommits.length > 0) {
+    markdown += `## Global Changes\n\n`;
+    markdown += generateChangelogMarkdown(globalCommits, options);
+  }
+
+  return markdown;
+}
+
+/**
+ * Parse repository URL from git remote
+ */
+export function getRepositoryUrl(cwd: string): string | undefined {
+  try {
+    const { execSync } = require('child_process');
+    const remoteUrl = execSync('git config --get remote.origin.url', {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+
+    // Convert SSH URL to HTTPS
+    if (remoteUrl.startsWith('git@')) {
+      return remoteUrl
+        .replace('git@', 'https://')
+        .replace('.com:', '.com/')
+        .replace('.git', '');
+    }
+
+    return remoteUrl.replace('.git', '');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Get compare URL for version range
+ */
+export function getCompareUrl(cwd: string, fromTag: string, toTag: string): string | undefined {
+  const repoUrl = getRepositoryUrl(cwd);
+  if (!repoUrl) return undefined;
+
+  return `${repoUrl}/compare/${fromTag}...${toTag}`;
+}

--- a/packages/project-release/src/executors/project-release/index.ts
+++ b/packages/project-release/src/executors/project-release/index.ts
@@ -2,6 +2,8 @@ import { PromiseExecutor, logger, ExecutorContext } from '@nx/devkit';
 import versionExecutor from '../version/index';
 import changelogExecutor from '../changelog/index';
 import publishExecutor from '../publish/index';
+import * as fs from 'fs';
+import * as path from 'path';
 
 interface ExecutorResult {
   success: boolean;
@@ -308,8 +310,6 @@ async function showWorkflowChanges(options: ProjectReleaseExecutorSchema, contex
     logger.info(`  Preset: ${options.preset || 'angular'}`);
 
     const changelogPath = `${projectRoot}/${options.changelogFile || 'CHANGELOG.md'}`;
-    const fs = require('fs');
-    const path = require('path');
     const fullChangelogPath = path.join(context.root, changelogPath);
 
     if (fs.existsSync(fullChangelogPath)) {
@@ -335,8 +335,6 @@ async function showWorkflowChanges(options: ProjectReleaseExecutorSchema, contex
     const publishDir = options.publishDir || `dist/${context.projectName}`;
     logger.info(`  Publish Directory: ${publishDir}`);
 
-    const fs = require('fs');
-    const path = require('path');
     const fullPublishDir = path.join(context.root, publishDir);
 
     if (fs.existsSync(fullPublishDir)) {

--- a/packages/project-release/tsconfig.json
+++ b/packages/project-release/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "ES2022"
   },
   "files": [],
   "include": [],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,8 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {
       "project-release": ["project-release/src/index.ts"]


### PR DESCRIPTION
## Summary
- Bumped package version from 1.1.0 to 1.1.1
- Refactored conventional-changelog integration with custom parser and markdown generator
- Split changelog logic into modular components for better maintainability
- Added custom commit parser and markdown generator modules
- Updated dependencies and TypeScript configuration

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Version bumped correctly