### PR TITLE
feat: add CI/CD workflows and comprehensive documentation

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,129 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.2.0) or leave empty for auto-detect'
+        required: false
+        type: string
+      releaseAs:
+        description: 'Release type (major, minor, patch, prerelease)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - major
+          - minor
+          - patch
+          - prerelease
+        default: ''
+      preid:
+        description: 'Prerelease identifier (alpha, beta, rc) - only for prerelease'
+        required: false
+        type: string
+      dryRun:
+        description: 'Dry run (preview without publishing)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  manual-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build
+        run: npx nx build @nx-project-release
+
+      - name: Build release command
+        id: cmd
+        run: |
+          CMD="npx nx run @nx-project-release:project-release"
+
+          # Add version or releaseAs
+          if [ -n "${{ inputs.version }}" ]; then
+            CMD="$CMD --version=${{ inputs.version }}"
+          elif [ -n "${{ inputs.releaseAs }}" ]; then
+            CMD="$CMD --releaseAs=${{ inputs.releaseAs }}"
+          fi
+
+          # Add preid if specified
+          if [ -n "${{ inputs.preid }}" ]; then
+            CMD="$CMD --preid=${{ inputs.preid }}"
+          fi
+
+          # Add git operations
+          if [ "${{ inputs.dryRun }}" == "false" ]; then
+            CMD="$CMD --gitCommit --gitTag --publish"
+            CMD="$CMD --gitCommitMessage='chore(release): @nx-project-release version {version} [skip ci]'"
+            CMD="$CMD --gitTagMessage='Release v{version}'"
+          else
+            CMD="$CMD --dryRun"
+          fi
+
+          echo "command=$CMD" >> $GITHUB_OUTPUT
+          echo "Running: $CMD"
+
+      - name: Run release
+        run: ${{ steps.cmd.outputs.command }}
+
+      - name: Push changes
+        if: inputs.dryRun == false
+        run: |
+          git push origin main --follow-tags
+
+      - name: Get new version
+        if: inputs.dryRun == false
+        id: version
+        run: |
+          VERSION=$(node -p "require('./packages/project-release/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Released version: $VERSION"
+
+      - name: Create GitHub Release
+        if: inputs.dryRun == false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract changelog for this version
+          if [ -f "packages/project-release/CHANGELOG.md" ]; then
+            CHANGELOG=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" packages/project-release/CHANGELOG.md | sed '1d;$d')
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="Release v$VERSION"
+            fi
+          else
+            CHANGELOG="Release v$VERSION"
+          fi
+
+          gh release create "v$VERSION" \
+            --title "Release v$VERSION" \
+            --notes "$CHANGELOG" \
+            --target main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,18 +92,51 @@ jobs:
 
       - name: Dry Run - Version Check
         run: |
-          echo "Running version dry-run to validate configuration..."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "🔢 DRY RUN: Version Executor"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Validating version configuration and checking what would change..."
+          echo ""
+
           npx nx run @nx-project-release:version --dryRun
+
+          echo ""
+          echo "✅ Version executor validated successfully"
+          echo ""
 
       - name: Dry Run - Changelog Check
         run: |
-          echo "Running changelog dry-run to validate configuration..."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "📝 DRY RUN: Changelog Executor"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Validating changelog configuration and preview generation..."
+          echo ""
+
           npx nx run @nx-project-release:changelog --dryRun
+
+          echo ""
+          echo "✅ Changelog executor validated successfully"
+          echo ""
 
       - name: Dry Run - Publish Check
         run: |
-          echo "Running publish dry-run to validate configuration..."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "📦 DRY RUN: Publish Executor"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Validating publish configuration and npm package..."
+          echo ""
+
           npx nx run @nx-project-release:publish --dryRun
+
+          echo ""
+          echo "✅ Publish executor validated successfully"
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "✅ ALL DRY RUN CHECKS PASSED"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
       - name: Comment on PR
         if: steps.release-preview.outputs.has_changes == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
@@ -11,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -29,3 +35,105 @@ jobs:
 
       - name: Test
         run: npx nx test @nx-project-release
+
+      - name: Release Dry Run - Show Analysis
+        id: release-preview
+        run: |
+          echo "## 🔍 Release Preview - What Would Happen" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This shows what the release process would do if this PR is merged:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Capture the show output
+          OUTPUT=$(npx nx run @nx-project-release:version --show 2>&1 || true)
+
+          # Check if there would be a version change
+          if echo "$OUTPUT" | grep -q "New version:"; then
+            CURRENT_VERSION=$(echo "$OUTPUT" | grep "Current version:" | awk '{print $3}')
+            NEW_VERSION=$(echo "$OUTPUT" | grep "New version:" | awk '{print $3}')
+            CHANGE_TYPE=$(echo "$OUTPUT" | grep "Detected:" | awk '{print $2}')
+
+            echo "### ✅ Version Change Detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- **Current Version**: \`$CURRENT_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **New Version**: \`$NEW_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "- **Change Type**: \`$CHANGE_TYPE\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            echo "### 📝 Release Actions" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "When merged to main, the automated release will:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "1. 🔢 Bump version from \`$CURRENT_VERSION\` → \`$NEW_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "2. 📝 Generate CHANGELOG.md from conventional commits" >> $GITHUB_STEP_SUMMARY
+            echo "3. 💾 Create git commit: \`chore(release): @nx-project-release version $NEW_VERSION [skip ci]\`" >> $GITHUB_STEP_SUMMARY
+            echo "4. 🏷️ Create git tag: \`v$NEW_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "5. 📤 Push commit and tag to main" >> $GITHUB_STEP_SUMMARY
+            echo "6. 🎉 Create GitHub Release for \`v$NEW_VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "7. 📦 Publish \`@divagnz/nx-project-release@$NEW_VERSION\` to npm" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "### ℹ️ No Version Change" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No release will be triggered - no conventional commits detected since last release." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Add full analysis details
+          echo "### 📊 Detailed Analysis" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Dry Run - Version Check
+        run: |
+          echo "Running version dry-run to validate configuration..."
+          npx nx run @nx-project-release:version --dryRun
+
+      - name: Dry Run - Changelog Check
+        run: |
+          echo "Running changelog dry-run to validate configuration..."
+          npx nx run @nx-project-release:changelog --dryRun
+
+      - name: Dry Run - Publish Check
+        run: |
+          echo "Running publish dry-run to validate configuration..."
+          npx nx run @nx-project-release:publish --dryRun
+
+      - name: Comment on PR
+        if: steps.release-preview.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const newVersion = '${{ steps.release-preview.outputs.new_version }}';
+            const body = `## 🚀 Release Preview
+
+            This PR will trigger a **release** when merged to main.
+
+            ### Version Change
+            - **New Version**: \`${newVersion}\`
+            - **Package**: \`@divagnz/nx-project-release@${newVersion}\`
+
+            ### What will happen:
+            1. ✅ Version bump
+            2. ✅ Changelog generation
+            3. ✅ Git tag creation
+            4. ✅ GitHub Release
+            5. ✅ npm publish
+
+            See the [job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for detailed analysis.
+
+            ---
+            *🤖 This is an automated release preview*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          # Remove local file dependency temporarily for CI
+          if grep -q '"@divagnz/nx-project-release": "file:' package.json; then
+            echo "Removing local file dependency for CI..."
+            npm pkg delete devDependencies.@divagnz/nx-project-release
+          fi
+          npm ci
 
       - name: Lint
         run: npx nx lint @nx-project-release
@@ -35,6 +41,11 @@ jobs:
 
       - name: Test
         run: npx nx test @nx-project-release
+
+      - name: Install plugin for dry-run checks
+        run: |
+          echo "Installing built plugin for dry-run validation..."
+          npm install --save-dev ./dist/project-release
 
       - name: Release Dry Run - Show Analysis
         id: release-preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/release.yml'
+
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'chore(release)')"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build
+        run: npx nx build @nx-project-release
+
+      - name: Check for changes
+        id: check
+        run: |
+          # Check if there are any commits since last tag
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$LAST_TAG" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "No previous tag found, will create first release"
+          else
+            CHANGES=$(git log $LAST_TAG..HEAD --oneline -- packages/project-release/ | grep -v "chore(release)" | wc -l)
+            if [ "$CHANGES" -gt 0 ]; then
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+              echo "Found $CHANGES commits since $LAST_TAG"
+            else
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+              echo "No changes since $LAST_TAG"
+            fi
+          fi
+
+      - name: Version, Changelog, and Tag
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          npx nx run @nx-project-release:version \
+            --gitCommit \
+            --gitTag \
+            --gitCommitMessage="chore(release): @nx-project-release version {version} [skip ci]" \
+            --gitTagMessage="Release v{version}"
+
+          npx nx run @nx-project-release:changelog \
+            --projectChangelogs
+
+      - name: Push changes
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          git push origin main --follow-tags
+
+      - name: Get new version
+        if: steps.check.outputs.has_changes == 'true'
+        id: version
+        run: |
+          VERSION=$(node -p "require('./packages/project-release/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $VERSION"
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract changelog for this version
+          if [ -f "packages/project-release/CHANGELOG.md" ]; then
+            CHANGELOG=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" packages/project-release/CHANGELOG.md | sed '1d;$d')
+          else
+            CHANGELOG="Release v$VERSION"
+          fi
+
+          gh release create "v$VERSION" \
+            --title "Release v$VERSION" \
+            --notes "$CHANGELOG" \
+            --target main
+
+      - name: Publish to npm
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npx nx run @nx-project-release:publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "project-release",
-  "version": "0.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "project-release",
-      "version": "0.0.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
+        "@divagnz/nx-project-release": "file:dist/project-release",
         "@eslint/js": "^9.8.0",
         "@nx/devkit": "21.5.3",
         "@nx/eslint": "21.5.3",
@@ -2183,6 +2184,23 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@divagnz/nx-project-release": {
+      "version": "1.1.1",
+      "resolved": "file:dist/project-release",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rxjs": "^7.8.1",
+        "semver": "^7.7.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=21.0.0"
+      },
+      "peerDependencies": {
+        "@nx/devkit": ">=21.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {},
   "private": true,
   "devDependencies": {
+    "@divagnz/nx-project-release": "file:dist/project-release",
     "@eslint/js": "^9.8.0",
     "@nx/devkit": "21.5.3",
     "@nx/eslint": "21.5.3",

--- a/packages/project-release/project.json
+++ b/packages/project-release/project.json
@@ -49,9 +49,39 @@
         ]
       }
     },
-    "project-release": {
+    "version": {
+      "executor": "@divagnz/nx-project-release:version",
       "options": {
-        "packageRoot": "dist/{projectRoot}"
+        "versionFiles": ["package.json"],
+        "versionPath": "version"
+      }
+    },
+    "changelog": {
+      "executor": "@divagnz/nx-project-release:changelog",
+      "options": {
+        "preset": "angular"
+      }
+    },
+    "publish": {
+      "executor": "@divagnz/nx-project-release:publish",
+      "dependsOn": ["build"],
+      "options": {
+        "publishDir": "dist/project-release",
+        "buildTarget": "build",
+        "registryType": "npm",
+        "registry": "https://registry.npmjs.org",
+        "access": "public",
+        "distTag": "latest"
+      }
+    },
+    "project-release": {
+      "executor": "@divagnz/nx-project-release:project-release",
+      "dependsOn": ["build"],
+      "options": {
+        "packageRoot": "dist/project-release",
+        "buildTarget": "build",
+        "versionFiles": ["package.json"],
+        "versionPath": "version"
       }
     },
     "lint": {

--- a/packages/project-release/src/executors/changelog/index.ts
+++ b/packages/project-release/src/executors/changelog/index.ts
@@ -6,13 +6,13 @@ import {
   getCommitsFromGit,
   parseCommits,
   filterCommitsByScope
-} from './commit-parser';
+} from './commit-parser.js';
 import {
   generateChangelogMarkdown,
   generateWorkspaceChangelog,
   getRepositoryUrl,
   ChangelogOptions
-} from './markdown-generator';
+} from './markdown-generator.js';
 
 export interface ChangelogExecutorSchema {
   dryRun?: boolean;

--- a/packages/project-release/src/executors/changelog/markdown-generator.ts
+++ b/packages/project-release/src/executors/changelog/markdown-generator.ts
@@ -1,4 +1,4 @@
-import { ParsedCommit, getCommitTypeTitle, COMMIT_TYPE_ORDER } from './commit-parser';
+import { ParsedCommit, getCommitTypeTitle, COMMIT_TYPE_ORDER } from './commit-parser.js';
 
 export interface ChangelogOptions {
   version?: string;


### PR DESCRIPTION
## Summary
Configure the plugin to use itself for releases (dogfooding) and add comprehensive CI/CD workflows and documentation.

## Changes

### Executor Configuration
- ✅ Added `version`, `changelog`, `publish`, and `project-release` executor targets to project.json
- ✅ Installed `@divagnz/nx-project-release@1.1.1` locally as dev dependency
- ✅ Configured publish target with npm registry settings

### CI/CD Workflows
- ✅ **Automated Release Workflow** (`.github/workflows/release.yml`)
  - Triggers on pushes to main branch
  - Automatically detects version changes using conventional commits
  - Creates git tags and GitHub releases
  - Publishes to npm
  - Skips if no changes since last release
  - Prevents release loops with `[skip ci]` in commit messages

- ✅ **Manual Release Workflow** (`.github/workflows/manual-release.yml`)
  - Workflow dispatch for on-demand releases
  - Configurable version or release type (major/minor/patch/prerelease)
  - Dry-run option for testing
  - Manual trigger from GitHub Actions UI

### Documentation Improvements
- ✅ Added **Quick Start** section with step-by-step setup
- ✅ Added **Basic Setup** guide for first-time users
- ✅ Enhanced **CI/CD Integration** section with:
  - Complete GitHub Actions examples (automated, manual, affected projects)
  - GitLab CI/CD configuration
  - CircleCI configuration
  - Required secrets documentation
  - Best practices and tips

## Benefits

1. **Dogfooding** - The plugin now uses itself for releases, validating it works correctly
2. **Automated Releases** - No manual intervention needed for releases
3. **Better Documentation** - Clear setup instructions for users without dev experience
4. **Multi-Platform Support** - CI/CD examples for GitHub, GitLab, and CircleCI
5. **Flexible Release Options** - Both automated and manual release workflows

## Testing

- [x] Executors properly configured in project.json
- [x] Plugin installs successfully locally
- [x] Dry-run of publish works correctly
- [x] Successfully published v1.1.1 using configured setup
- [x] Workflows validated for syntax
- [x] Documentation reviewed for clarity

## Usage

After merge, the repository will:
- Automatically create releases when code is pushed to main
- Allow manual releases via GitHub Actions UI
- Use the plugin itself for all release operations

Future releases can be triggered with:
```bash
npx nx run @nx-project-release:project-release --gitCommit --gitTag --publish
```

Or simply push to main and let CI handle it!

## Breaking Changes
None - fully backward compatible.

## Notes
- Workflows require `NPM_TOKEN` secret to be configured for publishing
- The release workflow skips releases if no changes detected since last tag
- Manual workflow allows testing with dry-run before actual release