### PR TITLE
fix: handle local file dependency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          # Remove local file dependency temporarily for CI
+          if grep -q '"@divagnz/nx-project-release": "file:' package.json; then
+            echo "Removing local file dependency for CI..."
+            npm pkg delete devDependencies.@divagnz/nx-project-release
+          fi
+          npm ci
 
       - name: Configure Git
         run: |
@@ -43,6 +49,11 @@ jobs:
 
       - name: Build
         run: npx nx build @nx-project-release
+
+      - name: Install built plugin
+        run: |
+          echo "Installing built plugin for release executors..."
+          npm install --save-dev ./dist/project-release
 
       - name: Check for changes
         id: check


### PR DESCRIPTION
## Problem
The release workflow fails during `npm ci` with:
```
Invalid: lock file's @divagnz/nx-project-release@1.1.1 does not satisfy @divagnz/nx-project-release@
Missing: @divagnz/nx-project-release@ from lock file
```

## Root Cause
The package.json has a local file dependency:
```json
"@divagnz/nx-project-release": "file:dist/project-release"
```

This causes package-lock.json to be out of sync in CI where the dist folder doesn't exist until after build.

## Solution
Apply the same fix we used in the PR workflow:
1. Remove the local file dependency before `npm ci`
2. Install the built plugin after the build step
3. Executors can then run with the freshly built plugin

## Changes
- ✅ Remove local file dependency before npm ci
- ✅ Install built plugin after build
- ✅ Matches PR workflow pattern

## Testing
- PR checks will validate the fix works
- After merge, release workflow should complete successfully
- Will create v1.1.3 release (minor bump from ESM fixes)
