### PR TITLE
fix: update release workflow to work with branch protection rules

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,122 @@
+name: Publish Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Only run if PR was merged and it's a release PR
+    if: |
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v') &&
+      contains(github.event.pull_request.title, 'chore(release)')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: |
+          # Remove local file dependency temporarily for CI
+          if grep -q '"@divagnz/nx-project-release": "file:' package.json; then
+            echo "Removing local file dependency for CI..."
+            npm pkg delete devDependencies.@divagnz/nx-project-release
+          fi
+          npm ci
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build
+        run: npx nx build @nx-project-release
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./packages/project-release/package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Create and push git tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+
+          # Check if tag already exists locally
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally, deleting..."
+            git tag -d "$TAG"
+          fi
+
+          # Create new tag
+          git tag -a "$TAG" -m "Release v$VERSION"
+
+          # Force push tag (in case it exists remotely from failed run)
+          git push origin "$TAG" --force
+
+          echo "Created and pushed tag: $TAG"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Extract changelog for this version
+          if [ -f "packages/project-release/CHANGELOG.md" ]; then
+            CHANGELOG=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" packages/project-release/CHANGELOG.md | sed '1d;$d')
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="Release v$VERSION"
+            fi
+          else
+            CHANGELOG="Release v$VERSION"
+          fi
+
+          # Delete release if it exists (from failed run)
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists, deleting..."
+            gh release delete "v$VERSION" --yes
+          fi
+
+          # Create new release
+          gh release create "v$VERSION" \
+            --title "Release v$VERSION" \
+            --notes "$CHANGELOG" \
+            --target main
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Create .npmrc with authentication
+          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
+          npx nx run @nx-project-release:publish
+
+      - name: Delete release branch
+        if: always()
+        continue-on-error: true
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          echo "Deleting release branch: $BRANCH"
+          git push origin --delete "$BRANCH" || echo "Branch already deleted"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,22 +74,15 @@ jobs:
             fi
           fi
 
-      - name: Version, Changelog, and Tag
+      - name: Version and Changelog (without tag)
         if: steps.check.outputs.has_changes == 'true'
         run: |
           npx nx run @nx-project-release:version \
             --gitCommit \
-            --gitTag \
-            --gitCommitMessage="chore(release): @nx-project-release version {version} [skip ci]" \
-            --gitTagMessage="Release v{version}"
+            --gitCommitMessage="chore(release): @nx-project-release version {version} [skip ci]"
 
           npx nx run @nx-project-release:changelog \
             --projectChangelogs
-
-      - name: Push changes
-        if: steps.check.outputs.has_changes == 'true'
-        run: |
-          git push origin main --follow-tags
 
       - name: Get new version
         if: steps.check.outputs.has_changes == 'true'
@@ -99,31 +92,49 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "New version: $VERSION"
 
-      - name: Create GitHub Release
+      - name: Create release branch and PR
         if: steps.check.outputs.has_changes == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="release/v${VERSION}-automated"
 
-          # Extract changelog for this version
+          # Create and push release branch
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+
+          # Extract changelog for PR body
           if [ -f "packages/project-release/CHANGELOG.md" ]; then
             CHANGELOG=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" packages/project-release/CHANGELOG.md | sed '1d;$d')
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="Release v$VERSION"
+            fi
           else
             CHANGELOG="Release v$VERSION"
           fi
 
-          gh release create "v$VERSION" \
-            --title "Release v$VERSION" \
-            --notes "$CHANGELOG" \
-            --target main
+          # Create PR
+          gh pr create \
+            --title "chore(release): v$VERSION" \
+            --body "## Automated Release v$VERSION
 
-      - name: Publish to npm
-        if: steps.check.outputs.has_changes == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          # Create .npmrc with authentication
-          echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
-          npx nx run @nx-project-release:publish
+This PR was automatically created by the release workflow.
+
+### Changes
+
+$CHANGELOG
+
+### Actions Required
+
+- Review the version bump and changelog
+- Merge this PR to trigger tag creation and npm publish
+
+### Post-Merge Actions
+
+The following will happen automatically after merge:
+- Git tag v$VERSION will be created
+- GitHub release will be created
+- Package will be published to npm" \
+            --base main \
+            --head "$BRANCH"


### PR DESCRIPTION
## Problem

The current release workflow tries to push directly to `main`, which fails due to branch protection rules requiring all changes go through pull requests:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution

Split the release workflow into two parts to respect branch protection:

### 1. **release.yml** - Create Release PR
- Triggers on pushes to main (non-release commits)
- Bumps version and generates changelog
- Creates release branch (`release/v{version}-automated`)
- Opens PR with version changes

### 2. **publish-release.yml** - Publish After Merge  
- Triggers when release PR is merged
- Creates git tag
- Creates GitHub release
- Publishes to npm
- Cleans up release branch

## Key Changes

- ✅ Removed `--gitTag` from initial version command (tag created after PR merge)
- ✅ Added branch creation and PR creation in release workflow
- ✅ Created new publish workflow triggered by PR merge
- ✅ Added handling for existing tags/releases from failed runs
- ✅ Added automatic cleanup of release branches

## Testing

This PR updates the workflows. After merge:
1. The next push to main should create a release PR automatically
2. Merging that PR should trigger tag creation and npm publish

## Related

- Fixes the issue from the failed release run that created tag v1.2.0 but couldn't push to main