### PR TITLE
fix(configure-artifact): add missing executor options and improve code quality

### DIFF
--- a/packages/project-release/src/generators/configure-artifact/schema.d.ts
+++ b/packages/project-release/src/generators/configure-artifact/schema.d.ts
@@ -6,5 +6,11 @@ export interface ConfigureArtifactSchema {
   artifactName?: string;
   dependsOn?: string[];
   exclude?: string[];
+  outputDir?: string;
+  include?: string[];
+  compressionLevel?: number;
+  preservePermissions?: boolean;
+  stripPrefix?: string;
+  metadata?: Record<string, any>;
   updatePublish?: boolean;
 }

--- a/packages/project-release/src/generators/configure-artifact/schema.json
+++ b/packages/project-release/src/generators/configure-artifact/schema.json
@@ -65,6 +65,42 @@
         ["**/*.map", "**/*.spec.ts"],
         ["**/test/**", "**/*.test.js"]
       ]
+    },
+    "outputDir": {
+      "type": "string",
+      "description": "Where to place the artifact (supports template variables: {projectName}, {version})",
+      "default": "dist/artifacts",
+      "x-prompt": "Output directory for artifacts?"
+    },
+    "include": {
+      "type": "array",
+      "description": "Glob patterns to include (default: all files)",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/*"]
+    },
+    "compressionLevel": {
+      "type": "number",
+      "description": "Compression level (0-9, where 9 is maximum compression)",
+      "default": 6,
+      "minimum": 0,
+      "maximum": 9
+    },
+    "preservePermissions": {
+      "type": "boolean",
+      "description": "Preserve file permissions (Unix-based systems)",
+      "default": true
+    },
+    "stripPrefix": {
+      "type": "string",
+      "description": "Remove prefix from archive paths (e.g., 'dist/apps/myapp')",
+      "examples": ["dist/apps/web-app", "build/output"]
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Additional metadata to include in artifact manifest (.artifact-metadata.json)",
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
## 🎯 Problem Statement

The `configure-artifact` generator was critically misaligned with the `artifact` executor:
- ❌ **Missing REQUIRED option**: `outputDir` was hardcoded instead of configurable
- ❌ **5 missing optional options**: `include`, `compressionLevel`, `preservePermissions`, `stripPrefix`, `metadata`
- ⚠️ **Code quality issues**: Variable naming collision and redundant default application

**Impact:** Users could not fully configure artifact creation through the generator, limiting flexibility for custom build workflows.

---

## ✅ Solution

### Critical Fix: `outputDir` Now Configurable
**Before:**
```typescript
outputDir: 'dist/artifacts',  // HARDCODED
```

**After:**
```typescript
outputDir: options.outputDir || 'dist/artifacts',  // Configurable via CLI/interactive
```

### Added All Missing Executor Options

| Option | Type | Description | Interactive Prompt |
|--------|------|-------------|--------------------|
| `outputDir` | string | Artifact output directory | ✅ Yes |
| `include` | array | Glob patterns to include | ❌ CLI only |
| `compressionLevel` | number | Compression level (0-9) | ✅ Yes |
| `preservePermissions` | boolean | Preserve Unix permissions | ✅ Yes |
| `stripPrefix` | string | Remove path prefix | ❌ CLI only |
| `metadata` | object | Custom manifest metadata | ❌ CLI only |

### Code Quality Improvements

**1. Fixed Variable Naming Collision**
```typescript
// Before (confusing - both use 'dir')
const { dir } = await prompt({ name: 'dir', ... });
sourceDir = dir;
// ...
const { dir } = await prompt({ name: 'dir', ... });
outputDir = dir;

// After (clear and distinct)
const { sourceDir: sourceDirValue } = await prompt({ name: 'sourceDir', ... });
sourceDir = sourceDirValue;
// ...
const { outputDir: outputDirValue } = await prompt({ name: 'outputDir', ... });
outputDir = outputDirValue;
```

**2. Removed Redundant Default**
- Eliminated duplicate default application for `outputDir`
- Cleaner code with single source of truth

---

## 📋 Changes

### Files Modified (3)
1. **schema.json** (+36 lines)
   - Added 6 new properties with proper types and validation
   - All defaults match executor defaults

2. **schema.d.ts** (+6 lines)
   - Extended interface with new optional properties
   - Proper TypeScript types (`Record<string, any>` for metadata)

3. **generator.ts** (+82 lines, -12 lines = +70 net)
   - Added 3 interactive prompts (outputDir, compressionLevel, preservePermissions)
   - Conditional option writing (only write if provided)
   - Improved variable naming
   - Removed redundant code

---

## 🧪 Testing

### Interactive Mode
```bash
nx g nx-project-release:configure-artifact
```
- ✅ Prompts for project selection
- ✅ Prompts for format, sourceDir, outputDir
- ✅ Prompts for compressionLevel, preservePermissions
- ✅ All values written correctly to project.json

### CLI Mode (Full Options)
```bash
nx g configure-artifact \
  --project=myapp \
  --sourceDir="dist/apps/myapp" \
  --outputDir="dist/release-artifacts" \
  --format=zip \
  --compressionLevel=9 \
  --preservePermissions=false \
  --stripPrefix="dist/apps/myapp" \
  --include="**/*.js,**/*.json" \
  --exclude="**/*.map"
```
- ✅ All options accepted
- ✅ Correct project.json configuration generated

### Build Validation
```bash
npx nx run @nx-project-release:build
```
- ✅ No TypeScript errors
- ✅ All schemas validate correctly

---

## 📊 Alignment Status

### Before This PR
```
Executor Options: 10 total
Generator Options: 4 available (40%)
Missing: outputDir*, include, compressionLevel, 
         preservePermissions, stripPrefix, metadata
* = REQUIRED by executor
```

### After This PR
```
Executor Options: 10 total
Generator Options: 10 available (100%) ✅
Missing: None
```

**Result:** 100% alignment achieved! 🎉

---

## 🚨 Breaking Changes

**None** - This is a purely additive change:
- Existing configurations continue to work unchanged
- All new options are optional with sensible defaults
- Backward compatible with all previous versions

---

## 💡 Usage Examples

### Before (Limited)
```bash
# Could only configure: sourceDir, format, artifactName, exclude, dependsOn
nx g configure-artifact \
  --project=myapp \
  --sourceDir="dist/apps/myapp" \
  --format=tgz
```

### After (Full Control)
```bash
# Can now configure ALL artifact executor options!
nx g configure-artifact \
  --project=myapp \
  --sourceDir="dist/apps/myapp" \
  --outputDir="dist/custom-artifacts" \
  --format=zip \
  --compressionLevel=9 \
  --preservePermissions=true \
  --stripPrefix="dist/apps/myapp" \
  --include="**/*.js,**/*.json,**/*.html" \
  --exclude="**/*.map,**/*.spec.js"
```

---

## 📈 Impact

### Benefits
- ✅ **Users can fully customize artifact creation** without manual project.json edits
- ✅ **Improved DX** with interactive prompts for common options
- ✅ **Better code quality** with clear variable naming
- ✅ **Complete feature parity** between generator and executor

### Migration
No migration needed - existing configurations work as-is.

---

## 🔗 Related

This PR addresses findings from the executor-generator congruence analysis where configure-artifact was identified as having critical gaps.

**Part of larger effort to align all generators with their executors.**