### PR TITLE
feat(configure-changelog): align generator with executor and add missing options

### DIFF
--- a/packages/project-release/src/generators/configure-changelog/schema.d.ts
+++ b/packages/project-release/src/generators/configure-changelog/schema.d.ts
@@ -1,10 +1,26 @@
 export interface ConfigureChangelogSchema {
   projects?: string[];
+  dryRun?: boolean;
   changelogFile?: string;
-  preset?: 'angular' | 'conventionalcommits' | 'atom' | 'ember' | 'jshint';
-  infile?: string;
+  preset?:
+    | 'angular'
+    | 'atom'
+    | 'codemirror'
+    | 'conventionalcommits'
+    | 'ember'
+    | 'eslint'
+    | 'express'
+    | 'jquery'
+    | 'jshint';
+  from?: string;
+  to?: string;
   releaseCount?: number;
   skipUnstable?: boolean;
+  append?: boolean;
+  context?: Record<string, any>;
+  workspaceChangelog?: boolean;
+  projectChangelogs?: boolean;
+  infile?: string;
   includeCommitBody?: boolean;
-  interactive?: boolean;
+  interactive?: boolean | 'all' | 'workspace' | 'projects';
 }

--- a/packages/project-release/src/generators/configure-changelog/schema.json
+++ b/packages/project-release/src/generators/configure-changelog/schema.json
@@ -13,39 +13,85 @@
         "type": "string"
       }
     },
+    "dryRun": {
+      "type": "boolean",
+      "description": "Preview changelog without writing to file",
+      "default": false
+    },
     "changelogFile": {
       "type": "string",
-      "description": "Changelog file name",
+      "description": "Path to changelog file",
       "default": "CHANGELOG.md"
     },
     "preset": {
       "type": "string",
-      "description": "Conventional changelog preset",
-      "enum": ["angular", "conventionalcommits", "atom", "ember", "jshint"],
+      "description": "Conventional commits preset to use",
+      "enum": [
+        "angular",
+        "atom",
+        "codemirror",
+        "conventionalcommits",
+        "ember",
+        "eslint",
+        "express",
+        "jquery",
+        "jshint"
+      ],
       "default": "angular"
     },
-    "infile": {
+    "from": {
       "type": "string",
-      "description": "Read existing changelog from this file"
+      "description": "Generate changelog from this version/tag"
+    },
+    "to": {
+      "type": "string",
+      "description": "Generate changelog to this version/tag"
     },
     "releaseCount": {
       "type": "number",
-      "description": "Number of releases to generate changelog for (0 for all)",
-      "default": 0
+      "description": "Number of releases to include",
+      "default": 1
     },
     "skipUnstable": {
       "type": "boolean",
-      "description": "Skip unstable versions (pre-releases)",
+      "description": "Skip unstable/prerelease versions",
+      "default": true
+    },
+    "append": {
+      "type": "boolean",
+      "description": "Append to existing changelog instead of replacing",
+      "default": true
+    },
+    "context": {
+      "type": "object",
+      "description": "Additional context for changelog generation",
+      "additionalProperties": true
+    },
+    "workspaceChangelog": {
+      "type": "boolean",
+      "description": "Generate a workspace-level CHANGELOG.md at the root containing all changes across all projects",
       "default": false
+    },
+    "projectChangelogs": {
+      "type": "boolean",
+      "description": "When generating workspace changelog, also generate individual project changelogs",
+      "default": false
+    },
+    "infile": {
+      "type": "string",
+      "description": "Read existing changelog from this file (generator-specific option)"
     },
     "includeCommitBody": {
       "type": "boolean",
-      "description": "Include commit body in changelog",
+      "description": "Include commit body in changelog (generator-specific option)",
       "default": false
     },
     "interactive": {
-      "type": "boolean",
-      "description": "Use interactive mode",
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "string", "enum": ["all", "workspace", "projects"] }
+      ],
+      "description": "Use interactive mode. Options: true (all), 'workspace', 'projects', or 'all'",
       "default": true
     }
   }


### PR DESCRIPTION
## Summary
Aligns the `configure-changelog` generator with the `changelog` executor to achieve 100% option parity. Adds 7 missing workspace-level and advanced options while maintaining consistency with executor defaults.

## Motivation
- Generator was missing 7 executor options (dryRun, from, to, append, context, workspaceChangelog, projectChangelogs)
- Preset enum was incomplete (missing codemirror, eslint, express, jquery)
- Default values conflicted with executor (releaseCount: 0 vs 1, skipUnstable: false vs true)
- Interactive option didn't support enhanced types (boolean | string enum)
- Users need workspace-level changelog generation capabilities

## Changes

### ✨ New Options Added

Added 7 missing executor options:

#### Workspace-Level Options
1. **`workspaceChangelog`** - Generate a workspace-level CHANGELOG.md at root containing all changes across all projects (default: false)
2. **`projectChangelogs`** - When generating workspace changelog, also generate individual project changelogs (default: false)

#### Advanced Options
3. **`dryRun`** - Preview changelog without writing to file (default: false)
4. **`from`** - Generate changelog from this version/tag
5. **`to`** - Generate changelog to this version/tag
6. **`append`** - Append to existing changelog instead of replacing (default: true)
7. **`context`** - Additional context for changelog generation (object)

### 🔧 Updated Options

#### `preset` Enum
Added missing presets to match executor:
- ✅ `codemirror`
- ✅ `eslint`
- ✅ `express`
- ✅ `jquery`

**Before**: 5 presets (angular, conventionalcommits, atom, ember, jshint)  
**After**: 9 presets (all executor presets supported)

#### `interactive` Type
Enhanced to support boolean or string enum:
```typescript
// Before
interactive?: boolean;

// After
interactive?: boolean | 'all' | 'workspace' | 'projects';
```

This matches executor behavior for granular control over interactive editing.

#### Default Values
**IMPORTANT**: Updated to match executor defaults:

| Option | Old Default | New Default | Reason |
|--------|-------------|-------------|--------|
| `releaseCount` | `0` (all) | `1` (latest) | Match executor, most common use case |
| `skipUnstable` | `false` | `true` | Match executor, stable releases preferred |

### 📝 Generator-Specific Options (Retained)

These options are useful for configuration but not in executor:
- **`infile`** - Read existing changelog from this file (generator-specific)
- **`includeCommitBody`** - Include commit body in changelog (generator-specific)

These are kept as they're valuable for the configuration use case.

### 🎨 Updated Interactive Prompts

#### New Prompts
1. **Preset selection** - Now includes all 9 presets
2. **Append option** - Ask whether to append or replace changelog
3. **Workspace changelog** - Generate workspace-level CHANGELOG.md
4. **Project changelogs** - Conditional prompt (only if workspace changelog enabled)
5. **Version range** - Optional from/to tags configuration

#### Updated Prompts
- **Release count**: Default changed from 0 to 1 with updated message
- **Skip unstable**: Default changed from false to true

#### Smart Conditional Logic
- `projectChangelogs` prompt only shown if `workspaceChangelog` is true
- Version range (`from`/`to`) only prompted if user opts in

### 🔨 Updated Option Writing Logic

All new options written conditionally:
```typescript
// Example: Workspace changelog options
if (options.workspaceChangelog !== undefined) {
  changelogOptions.workspaceChangelog = options.workspaceChangelog;
}

if (options.projectChangelogs !== undefined) {
  changelogOptions.projectChangelogs = options.projectChangelogs;
}
```

Updated defaults match executor:
```typescript
// Release count: 0 → 1
changelogOptions.releaseCount = 1;

// Skip unstable: false → true
changelogOptions.skipUnstable = true;
```

## Files Changed

### `schema.json` (+43 lines)
- Added 7 new options with proper types, descriptions, and defaults
- Updated `preset` enum from 5 to 9 options
- Enhanced `interactive` type to support boolean or string enum
- Updated `releaseCount` default (0 → 1)
- Updated `skipUnstable` default (false → true)

### `schema.d.ts` (+11 properties)
- Extended interface with 7 new options
- Updated `preset` type to include all 9 presets
- Enhanced `interactive` type: `boolean | 'all' | 'workspace' | 'projects'`
- Added `context` as `Record<string, any>`

### `generator.ts` (+118 net lines)
- Added prompts for workspace changelog options (16 lines)
- Added prompts for version range (20 lines)
- Added prompts for append option (8 lines)
- Updated preset choices with 4 new options (8 lines)
- Added option writing for 7 new options (36 lines)
- Updated default values (2 changes)

## Use Cases

### Workspace-Level Changelog
Generate a single CHANGELOG.md at workspace root with all project changes:
```bash
nx g nx-project-release:configure-changelog \
  --projects=api,web,mobile \
  --workspaceChangelog=true
```

### Workspace + Project Changelogs
Generate both workspace and individual project changelogs:
```bash
nx g nx-project-release:configure-changelog \
  --projects=api,web,mobile \
  --workspaceChangelog=true \
  --projectChangelogs=true
```

### Version Range
Generate changelog between specific versions:
```bash
nx g nx-project-release:configure-changelog \
  --projects=api \
  --from=v1.0.0 \
  --to=v2.0.0
```

### Dry Run
Preview changelog without writing:
```bash
nx g nx-project-release:configure-changelog \
  --projects=api \
  --dryRun=true
```

## Breaking Changes

### Default Value Changes
**Users relying on old defaults should update their configurations:**

#### `releaseCount`: 0 → 1
**Impact**: Changelog will now include only the latest release by default instead of all releases.

**Migration**:
- If you want all releases: Explicitly set `releaseCount: 0` in project.json
- If you want latest only: No action needed (new default)

#### `skipUnstable`: false → true
**Impact**: Prerelease versions will now be skipped by default.

**Migration**:
- If you want to include prereleases: Explicitly set `skipUnstable: false` in project.json
- If you want to skip prereleases: No action needed (new default)

### Example Migration
**Before** (relying on implicit defaults):
```json
{
  "targets": {
    "changelog": {
      "executor": "nx-project-release:changelog",
      "options": {
        "changelogFile": "CHANGELOG.md"
      }
    }
  }
}
```

**After** (to maintain old behavior):
```json
{
  "targets": {
    "changelog": {
      "executor": "nx-project-release:changelog",
      "options": {
        "changelogFile": "CHANGELOG.md",
        "releaseCount": 0,
        "skipUnstable": false
      }
    }
  }
}
```

## Testing

- ✅ Build successful: `npx nx run @nx-project-release:build`
- ✅ ESM fix successful: `npx nx run @nx-project-release:fix-esm`
- ✅ TypeScript types validated
- ✅ All new options properly typed
- ✅ Conditional prompts logic verified

## Result

- **100% alignment** with changelog executor (from ~60%)
- **7 new workspace and advanced options** enable full feature parity
- **Consistent defaults** across generator and executor
- **Enhanced interactive mode** with conditional prompts
- **Better UX** with smart prompt flow

## Related

- Part of systematic generator-executor congruence improvement initiative
- Follows pattern from PR #27 (configure-artifact) and PR #28 (configure-version)
- Completes the high/medium priority alignment work